### PR TITLE
Revise tags / Unit tests for search.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,12 +20,11 @@ from models import db, Account, Comment, Like, Tag, Story
 from story import (
     post_story,
     parse_id,
-    extract_tags,
     add_tags,
     get_displayable_stories,
     get_poster_username,
 )
-from search import search_db
+from search import search_db, get_query_tokens
 
 
 load_dotenv(find_dotenv())
@@ -219,7 +218,7 @@ def post():
     userid = current_user.id
     text = flask.request.form.get("text")
     title = flask.request.form.get("title")
-    tags = extract_tags(flask.request.form.get("tags"))
+    tags = get_query_tokens(flask.request.form.get("tags"))
     new_story = Story(
         parent=parent,
         userid=userid,

--- a/search.py
+++ b/search.py
@@ -35,7 +35,7 @@ def search_db(query: str) -> list:
     return list(matching_stories)
 
 
-def get_query_tokens(query: str) -> list:
+def get_query_tokens(query: str) -> set:
     """
     Takes a query string and returns a list of tokens.
     """

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,27 +1,27 @@
 <html>
 
-<head>
-    <title>Post a story</title>
-    <link rel="stylesheet" href="/static/post.css" />
-</head>
+    <head>
+        <title>Post a story</title>
+        <link rel="stylesheet" href="/static/post.css" />
+    </head>
 
-<body>
-    
-    <div class="content">
-        <img src="static/logo2.png" class="logo">
-        <h1>Create a story</h1>
-        <form method="POST" action="/post?parent={{parent_id}}">
-            <input class="title_field" id="title" type="text" name="title" placeholder="Title">
-            <br>
-            <input class="text_field" id="text" type="text" name="text" placeholder="Placeholder. story here.">
-            <br>
-            <input class="tags_field" id="tags" type="text" name="tags" placeholder="Placeholder. tags here.">
-            <br>
-            <input class="post_submit" id="submit_button" type="submit" value="Submit Post">
+    <body>
 
-        </form>
-    </div>
+        <div class="content">
+            <img src="static/logo2.png" class="logo">
+            <h1>Create a story</h1>
+            <form method="POST" action="/post?parent={{parent_id}}">
+                <input class="title_field" id="title" type="text" name="title" placeholder="Title">
+                <br>
+                <input class="text_field" id="text" type="text" name="text" placeholder="Placeholder. story here.">
+                <br>
+                <input class="tags_field" id="tags" type="text" name="tags" placeholder="Enter space separated tags.">
+                <br>
+                <input class="post_submit" id="submit_button" type="submit" value="Submit Post">
 
-</body>
+            </form>
+        </div>
+
+    </body>
 
 </html>

--- a/test_search.py
+++ b/test_search.py
@@ -1,0 +1,59 @@
+"""
+Module for testing search.py
+"""
+# pylint: disable=missing-function-docstring
+
+import unittest
+from search import get_query_tokens
+
+
+class GetQueryTokensTests(unittest.TestCase):
+    """
+    This Class contains tests for the get_query_tokens function of search.py
+    """
+
+    def test_regular_string(self):
+        test_string = "Sci-Fi Fantasy Adventure"
+        expected_output = set(["sci-fi", "fantasy", "adventure"])
+        actual_output = get_query_tokens(test_string)
+        self.assertEqual(expected_output, actual_output)
+
+    def test_duplicate_string(self):
+        test_string = "word1 word1 word1"
+        expected_output = set(["word1"])
+        actual_output = get_query_tokens(test_string)
+        self.assertEqual(expected_output, actual_output)
+
+    def test_empty_string(self):
+        test_string = ""
+        expected_output = set([])
+        actual_output = get_query_tokens(test_string)
+        self.assertEqual(expected_output, actual_output)
+
+    def test_whitespace_string(self):
+        test_string = "     "
+        expected_output = set([])
+        actual_output = get_query_tokens(test_string)
+        self.assertEqual(expected_output, actual_output)
+
+    def test_short_string(self):
+        test_string = "word"
+        expected_output = set(["word"])
+        actual_output = get_query_tokens(test_string)
+        self.assertEqual(expected_output, actual_output)
+
+    def test_weird_string(self):
+        test_string = ",,,,,,,word1,,,, ,,,,,@@@@,,,,,,word2"
+        expected_output = set([",,,,,,,word1,,,,", ",,,,,@@@@,,,,,,word2"])
+        actual_output = get_query_tokens(test_string)
+        self.assertEqual(expected_output, actual_output)
+
+    def test_extra_whitespace_string(self):
+        test_string = "word1   word2          word3"
+        expected_output = set(["word1", "word2", "word3"])
+        actual_output = get_query_tokens(test_string)
+        self.assertEqual(expected_output, actual_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_story.py
+++ b/test_story.py
@@ -58,7 +58,7 @@ class ExtractTagsTests(unittest.TestCase):
 
 class ParseIdTests(unittest.TestCase):
     """
-    This Class contains tests for the extract_tags function of story.py
+    This Class contains tests for the parse_id function of story.py
     """
 
     def test_regular_string(self):


### PR DESCRIPTION
I updated the tag separator to be spaces instead of commas because of cases where the user enters a tag like 'Science fiction, ...' the 'Science fiction' would have been parsed as one 'science fiction' tag before, but now it will be parsed as 'science' and 'fiction' tags. This is helpful because search queries are separated by spaces meaning that it would have been impossible to search for 'science fiction' previously with the current search method. There are other alternatives that I'm thinking about as well, but I think this method works for our purposes at the moment.

In app.py, I modified tag extracting to use the same function that search uses for extracting words.
In search.py, I changed the function signature to actually reflect what is being returned by the function.
In post.html, I specified to users that the tags should be space separated.
In test_story.py, I changed a docstring that had the wrong info
Created test_search.py and wrote tests for get_query_tokens function